### PR TITLE
Follow standard logging patterns and expect proper logger

### DIFF
--- a/src/auth0V1.js
+++ b/src/auth0V1.js
@@ -6,7 +6,9 @@ const cache = require('./cache');
 
 // TODO: get from options
 const REFRESH_TOKEN_CLIENT_ID = process.env.DEFAULT_TARGET_ID || 'QkxOvNz4fWRFT6vcq79ylcIuolFz2cwN';
-let logger = console.log;
+let logger = process.env.NODE_DEBUG && process.env.NODE_DEBUG.includes('cimpress-auth0-client-request-promise')
+  ? console.log
+  : () => { };
 
 const generateAuthV1TokenCacheKey = config =>
   (config.clientId ? `${config.targetId}-${config.clientId}` : `${config.targetId}`);

--- a/src/auth0V2.js
+++ b/src/auth0V2.js
@@ -4,7 +4,9 @@ const request = require('request-promise');
 const cache = require('./cache');
 const auth0V1 = require('./auth0V1');
 
-let logger = console.log;
+let logger = process.env.NODE_DEBUG && process.env.NODE_DEBUG.includes('cimpress-auth0-client-request-promise')
+  ? console.log
+  : () => { };
 
 const generateAuthV2TokenCacheKey = (config, audience) => `${audience}-${config.clientId}`;
 

--- a/src/cache.js
+++ b/src/cache.js
@@ -10,7 +10,9 @@ const defaultCache = {
 
 let credentialCache = defaultCache;
 let keyGenFunc;
-let logger;
+let logger = process.env.NODE_DEBUG && process.env.NODE_DEBUG.includes('cimpress-auth0-client-request-promise')
+  ? console.log
+  : () => { };
 
 const parseCacheControlHeader = (headers) => {
   if (headers) {

--- a/src/passedInAuth.js
+++ b/src/passedInAuth.js
@@ -3,7 +3,9 @@ const _ = require('lodash');
 const auth0V2 = require('./auth0V2');
 const cache = require('./cache');
 
-let logger = console.log;
+let logger = process.env.NODE_DEBUG && process.env.NODE_DEBUG.includes('cimpress-auth0-client-request-promise')
+  ? console.log
+  : () => { };
 
 const makeRequest = (options, retryLoop) => {
   const requestOptions = _.assign({}, options);


### PR DESCRIPTION
This feels right to me (rejecting an improper logger, logging to console.log by default) but I'm not used to JS logging conventions.
My general idea for what to level to log at was:
If an error is thrown/returned, that's a debug
If it doesn't seem like a debug but doesn't seem like an error/warning, it's info
If it's an error that this library is swallowing and doesn't seem debug worthy then log as error.

By default this all logs to console.log, should errors log to console.err maybe?