### PR TITLE
FN-639 replace jsonwebtoken dependency with jwt-decode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -295,10 +295,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "base64url": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/base64url/-/base64url-2.0.0.tgz",
-      "integrity": "sha1-6sFuA+oUOO/5Qj1puqNiYu0fcLs="
-    },
     "bcrypt-pbkdf": {
       "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
@@ -390,10 +386,6 @@
       "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
-    },
-    "buffer-equal-constant-time": {
-      "version": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "builtin-modules": {
       "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -948,14 +940,6 @@
       "optional": true,
       "requires": {
         "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-      }
-    },
-    "ecdsa-sig-formatter": {
-      "version": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-      "integrity": "sha1-S8kmJ07Dtau1AW5+HWCSGsJisqE=",
-      "requires": {
-        "base64url": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/base64url/-/base64url-2.0.0.tgz",
-        "safe-buffer": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.0.tgz"
       }
     },
     "end-of-stream": {
@@ -1715,10 +1699,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "isemail": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/isexe/-/isexe-2.0.0.tgz",
@@ -1728,16 +1708,6 @@
     "isstream": {
       "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "joi": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-        "isemail": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/isemail/-/isemail-1.2.0.tgz",
-        "moment": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-        "topo": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/topo/-/topo-1.1.0.tgz"
-      }
     },
     "js-tokens": {
       "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
@@ -1787,25 +1757,6 @@
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
-    "jsonwebtoken": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-      "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
-      "requires": {
-        "joi": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/joi/-/joi-6.10.1.tgz",
-        "jws": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/jws/-/jws-3.1.4.tgz",
-        "lodash.once": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/lodash.once/-/lodash.once-4.1.1.tgz",
-        "ms": "2.0.0",
-        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
-    },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
@@ -1822,24 +1773,10 @@
         }
       }
     },
-    "jwa": {
-      "version": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-      "integrity": "sha1-oFUs4CIHQs1S4VN3SjKQXDDnVuU=",
-      "requires": {
-        "base64url": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/base64url/-/base64url-2.0.0.tgz",
-        "buffer-equal-constant-time": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-        "ecdsa-sig-formatter": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.9.tgz",
-        "safe-buffer": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.0.tgz"
-      }
-    },
-    "jws": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/jws/-/jws-3.1.4.tgz",
-      "integrity": "sha1-+ei5M46KhHJ31kRLFGT2GIDgUKI=",
-      "requires": {
-        "base64url": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/base64url/-/base64url-2.0.0.tgz",
-        "jwa": "https://registry.npmjs.org/jwa/-/jwa-1.1.5.tgz",
-        "safe-buffer": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/safe-buffer/-/safe-buffer-5.1.0.tgz"
-      }
+    "jwt-decode": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-2.2.0.tgz",
+      "integrity": "sha1-fYa9VmefWM5qhHBKZX3TkruoGnk="
     },
     "latest-version": {
       "version": "1.0.1",
@@ -1966,10 +1903,6 @@
         "lodash.isarray": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
       }
     },
-    "lodash.once": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-    },
     "lolex": {
       "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
@@ -2087,10 +2020,6 @@
           }
         }
       }
-    },
-    "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "ms": {
       "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
@@ -3009,13 +2938,6 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "topo": {
-      "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "requires": {
-        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-      }
-    },
     "tough-cookie": {
       "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
@@ -3192,7 +3114,8 @@
     },
     "xtend": {
       "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "yallist": {
       "version": "2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,6 +392,15 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "caller-id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
+      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+      "dev": true,
+      "requires": {
+        "stack-trace": "0.0.10"
+      }
+    },
     "caller-path": {
       "version": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
@@ -2021,6 +2030,15 @@
         }
       }
     },
+    "mock-require": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
+      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+      "dev": true,
+      "requires": {
+        "caller-id": "0.1.0"
+      }
+    },
     "ms": {
       "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
@@ -2801,6 +2819,12 @@
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "stealthy-require": {
       "version": "https://mcpartifactory.cimpress.net/artifactory/api/npm/npm-virtual/stealthy-require/-/stealthy-require-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "jsonwebtoken": "^7.1.9",
+    "jwt-decode": "^2.2.0",
     "lodash": "^4.17.4",
     "parse-cache-control": "^1.0.1",
     "request": "^2.81.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-import": "^2.3.0",
     "eslint-plugin-promise": "^3.5.0",
     "mocha": "^3.4.2",
+    "mock-require": "^2.0.2",
     "nock": "^9.0.13",
     "rewire": "^2.5.2",
     "sinon": "^2.3.2"

--- a/src/auth0V1.js
+++ b/src/auth0V1.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const jwt = require('jsonwebtoken');
+const jwtDecode = require('jwt-decode');
 const request = require('request-promise');
 const cache = require('./cache');
 const re = require('./requestEmitter');
@@ -16,7 +16,7 @@ const generateAuthV1TokenCacheKey = config =>
 
 const saveV1TokenInCache = (config, token) => {
   const cacheKey = generateAuthV1TokenCacheKey(config);
-  const decodedToken = jwt.decode(token);
+  const decodedToken = jwtDecode(token);
   return cache.set(cacheKey, token, decodedToken.exp - decodedToken.iat)
     .catch(err => logger(`Error saving v1 token ${cacheKey} in cache: ${JSON.stringify(err)}`));
 };

--- a/src/auth0V2.js
+++ b/src/auth0V2.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const jwt = require('jsonwebtoken');
+const jwtDecode = require('jwt-decode');
 const request = require('request-promise');
 const cache = require('./cache');
 const auth0V1 = require('./auth0V1');
@@ -21,7 +21,7 @@ const retrieveV2TokenFromCache = (config, audience) => {
 
 const saveV2TokenInCache = (config, audience, token) => {
   const cacheKey = generateAuthV2TokenCacheKey(config, audience);
-  const decodedToken = jwt.decode(token);
+  const decodedToken = jwtDecode(token);
   return cache.set(cacheKey, token, decodedToken.exp - decodedToken.iat)
     .catch((error) => {
       logger(`Error saving v2 token ${cacheKey} in cache: ${JSON.stringify(error)}`);

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,7 +1,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 const parseCacheControl = require('parse-cache-control');
-const jwt = require('jsonwebtoken');
+const jwtDecode = require('jwt-decode');
 
 const defaultCache = {
   get: () => Promise.resolve(),
@@ -30,7 +30,7 @@ const parseCacheControlHeader = (headers) => {
 const constructCacheKey = (options) => {
   try {
     if (options.auth && options.auth.bearer) {
-      const decodedToken = jwt.decode(options.auth.bearer);
+      const decodedToken = jwtDecode(options.auth.bearer);
       if (decodedToken && decodedToken.sub) {
         return Promise.resolve(`${options.method}-${options.uri}-${decodedToken.sub}`);
       }

--- a/test/service/authV1Request.service.js
+++ b/test/service/authV1Request.service.js
@@ -1,11 +1,10 @@
 /**
  * This test calls an API that expects a delegated token.
  */
-const request = require('../../index');
+let request = require('../../index');
 const expect = require('chai').expect;
 const nock = require('nock');
-const sinon = require('sinon');
-const jwt = require('jsonwebtoken');
+const mock = require('mock-require');
 
 describe('Auth0 v1 delegation', () => {
   const refreshToken = '12345678';
@@ -13,12 +12,12 @@ describe('Auth0 v1 delegation', () => {
   const authV1Token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ';
   const callingClientId = 'abcd';
   const v1AuthServer = 'https://v1auth.com';
-  let jwtDecodeStub;
 
   before(() => {
-    jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => 'abcd');
+    mock('jwt-decode', () => ({
+      sub: 'abcd',
+    }));
+    request = mock.reRequire('../../index');
   });
 
   beforeEach(() => {
@@ -33,7 +32,7 @@ describe('Auth0 v1 delegation', () => {
   });
 
   after(() => {
-    jwtDecodeStub.restore();
+    mock.stopAll();
   });
 
   afterEach(() => {

--- a/test/service/cacheAllSetting.service.js
+++ b/test/service/cacheAllSetting.service.js
@@ -1,24 +1,21 @@
 /**
  * Checks the behavior of the cacheAll attribute that can be passed in when making a request
  */
-const request = require('../../index');
+let request = require('../../index');
 const expect = require('chai').expect;
 const nock = require('nock');
-const sinon = require('sinon');
-const jwt = require('jsonwebtoken');
 const Promise = require('bluebird');
+const mock = require('mock-require');
 
 describe('Setting the cacheAll field in options', () => {
-  let jwtDecodeStub;
   let oldCache;
 
   before(() => {
     oldCache = request.credentialCache;
-    jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => ({
-        sub: 'abcd',
-      }));
+    mock('jwt-decode', () => ({
+      sub: 'abcd',
+    }));
+    request = mock.reRequire('../../index');
   });
 
   afterEach(() => {
@@ -27,7 +24,7 @@ describe('Setting the cacheAll field in options', () => {
   });
 
   after(() => {
-    jwtDecodeStub.restore();
+    mock.stopAll();
   });
 
   const config = {

--- a/test/service/cacheRequests.service.js
+++ b/test/service/cacheRequests.service.js
@@ -1,24 +1,21 @@
 /**
  * This test calls an API that expects a client credentials grant.
  */
-const request = require('../../index');
+let request = require('../../index');
 const expect = require('chai').expect;
 const nock = require('nock');
-const sinon = require('sinon');
-const jwt = require('jsonwebtoken');
 const Promise = require('bluebird');
+const mock = require('mock-require');
 
 describe('Making a new request', () => {
-  let jwtDecodeStub;
   let oldCache;
 
   before(() => {
     oldCache = request.credentialCache;
-    jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => ({
-        sub: 'abcd',
-      }));
+    mock('jwt-decode', () => ({
+      sub: 'abcd',
+    }));
+    request = mock.reRequire('../../index');
   });
 
   afterEach(() => {
@@ -27,7 +24,7 @@ describe('Making a new request', () => {
   });
 
   after(() => {
-    jwtDecodeStub.restore();
+    mock.stopAll();
   });
 
   const config = {

--- a/test/service/passedInAuth.service.js
+++ b/test/service/passedInAuth.service.js
@@ -1,23 +1,21 @@
 /**
  * This test calls an API that expects a client credentials grant.
  */
-const request = require('../../index');
+let request = require('../../index');
 const expect = require('chai').expect;
 const nock = require('nock');
-const sinon = require('sinon');
-const jwt = require('jsonwebtoken');
+const mock = require('mock-require');
 
 describe('When an auth token is passed in', () => {
-  let jwtDecodeStub;
-
   before(() => {
-    jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => 'abcd');
+    mock('jwt-decode', () => ({
+      sub: 'abcd',
+    }));
+    request = mock.reRequire('../../index');
   });
 
   after(() => {
-    jwtDecodeStub.restore();
+    mock.stopAll();
   });
 
   afterEach(() => {

--- a/test/unit/cache.unit.js
+++ b/test/unit/cache.unit.js
@@ -1,7 +1,5 @@
 const rewire = require('rewire');
 const expect = require('chai').expect;
-const sinon = require('sinon');
-const jwt = require('jsonwebtoken');
 
 const cache = rewire('../../src/cache');
 
@@ -54,11 +52,6 @@ describe('Cache constructCacheKey', () => {
     const method = 'POST';
     const uri = 'http://example.com';
     const sub = '123';
-    const jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => ({
-        sub,
-      }));
 
     const options = {
       method,
@@ -71,7 +64,6 @@ describe('Cache constructCacheKey', () => {
     return constructCacheKey(options).then((cacheKey) => {
       expect(cacheKey).to.not.be.undefined;
       expect(cacheKey).to.equal(`${method}-${uri}-${sub}`);
-      jwtDecodeStub.restore();
     });
   });
 
@@ -79,9 +71,6 @@ describe('Cache constructCacheKey', () => {
     const bearer = 'abc';
     const method = 'POST';
     const uri = 'http://example.com';
-    const jwtDecodeStub = sinon
-      .stub(jwt, 'decode')
-      .callsFake(() => undefined);
 
     const options = {
       method,
@@ -94,7 +83,6 @@ describe('Cache constructCacheKey', () => {
     return constructCacheKey(options).then((cacheKey) => {
       expect(cacheKey).to.not.be.undefined;
       expect(cacheKey).to.equal(`${method}-${uri}`);
-      jwtDecodeStub.restore();
     });
   });
 


### PR DESCRIPTION
jsonwebtoken is only a valid dependency for node applications, it completely breaks when trying to use in the browser. Since we only use the package for decoding jwts, this can be easily replaced by the jwt-decode package which is cross-platform